### PR TITLE
Add the slack link to the community menu button

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <a class="p-2 text-dark" href="#">About</a>
             <a class="p-2 text-dark" href="#">Contribute</a>
             <a class="p-2 text-dark" href="#">Connect</a>
-            <a class="p-2 text-dark" href="#">Community <i class="fab fa-slack-hash"></i></a>
+            <a class="p-2 text-dark" href="http://bit.ly/2mSDz5k">Community <i class="fab fa-slack-hash"></i></a>
         </nav>
     </div>
     <div class="px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <a class="p-2 text-dark" href="#">About</a>
             <a class="p-2 text-dark" href="#">Contribute</a>
             <a class="p-2 text-dark" href="#">Connect</a>
-            <a class="p-2 text-dark" href="http://bit.ly/2mSDz5k">Community <i class="fab fa-slack-hash"></i></a>
+            <a class="p-2 text-dark" href="https://openfloodai.slack.com" target="_blank">Community <i class="fab fa-slack-hash"></i></a>
         </nav>
     </div>
     <div class="px-3 py-3 pt-md-5 pb-md-4 mx-auto text-center">


### PR DESCRIPTION
I couldn't find a section, only a link on the menu. I updated that one. 