### PR TITLE
README.md fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,46 @@
+## How to contribute to openfloodai.github.io?
+
+### Fork the repository
+Click on the Fork button at the top of the Github page in https://github.com/OpenFloodAI/openfloodai.github.io
+
+This creates a copy(fork) of the repository in your Github account.
+
+### Clone the repository
+To make your own local copy of the repository you would like to contribute to, type in the terminal:
+
+```
+git clone https://github.com/<your-username>/openfloodai.github.io.git
+```
+
+where you replace <your-username> by your Github username. You can find this link on clicking the green "Clone or download" button in your repo (in your account).
+
+
+### Create a New Branch
+```
+cd openfloodai.github.io
+git branch <newbranch>
+git checkout <newbranch>
+```
+Where you can replace <newbranch> by the name of the branch you'd like to create.
+This checks you out to the new branch.
+
+### Make your changes
+Fix the issues or contribute as you would like to, by making appropriate changes.
+Once you have made your changes, commit them as:
+```
+git add .
+git commit -m "<a suitable message for the commit>"
+```
+
+
+## Push your changes to your repo
+```
+git push --set-upstream origin new-branch
+```
+
+
+## Create pull request
+Once you have pushed your branch, navigate to the forked repository on your GitHub webpage and toggle to the branch you just pushed to see the changes you have made in-browser.
+
+At this point, it is possible to make a pull request to the original repository. Click on the Pull Request button which shows up at the top of your repo. Make sure your branch is mergeable.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![GitHub issues](https://img.shields.io/github/issues/OpenFloodAI/openfloodai.github.io) ![GitHub forks](https://img.shields.io/github/forks/OpenFloodAI/openfloodai.github.io?style=social) ![GitHub stars](https://img.shields.io/github/stars/OpenFloodAI/openfloodai.github.io?style=social)
 
-## How to contribute to openfloodai.github.io?**
+## How to contribute to openfloodai.github.io?
 
 ### Fork the repository
 Click on the Fork button at the top of the Github page in https://github.com/OpenFloodAI/openfloodai.github.io
@@ -12,7 +12,7 @@ Click on the Fork button at the top of the Github page in https://github.com/Ope
 This creates a copy(fork) of the repository in your Github account.
 
 ### Clone the repository
-To make your own local copy of the repository you would like to contribute to, in the terminal type:
+To make your own local copy of the repository you would like to contribute to, type in the terminal:
 
 ```
 git clone https://github.com/<your-username>/openfloodai.github.io.git
@@ -25,9 +25,9 @@ where you replace <your-username> by your Github username. You can find this lin
 ```
 cd openfloodai.github.io
 git branch <newbranch>
-git checkout new-branch
+git checkout <newbranch>
 ```
-where you can replace <newbranch> by the name of the branch you'd like to create.
+Where you can replace <newbranch> by the name of the branch you'd like to create.
 This checks you out to the new branch.
 
 ### Make your changes


### PR DESCRIPTION
Fixed 4 typos: 

- Removed "**": 
`How to contribute to openfloodai.github.io?`
- Fixed a typo a sentence: 
`To make your own local copy of the repository you would like to contribute to, type in the terminal`
- Capitalized the first letter: 
`Where you can replace <newbranch> by the name of the branch you'd like to create.`
- Changed `new-branch` to `<newbranch>`, as such name was used previously